### PR TITLE
[feat][resume] Import resume into site

### DIFF
--- a/content/pages/about.mdx
+++ b/content/pages/about.mdx
@@ -5,6 +5,6 @@ slug: "/about"
 
 I'm Johanan Idicula, a software developer and recent graduate of McGill University. This is where I write about software engineering, data science, cooking, and finance.
 
-My resume can be viewed [here](https://forcepush.tech/jidicula-resume/jidicula-resume.pdf).
+My resume can be viewed [here](/jidicula-resume/jidicula-resume.pdf).
 
 Questions? Comments? My email is at the bottom of this page.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -111,6 +111,7 @@ module.exports = {
         name: `jidicula-resume`,
         remote: `https://github.com/jidicula/jidicula-resume.git`,
         branch: `master`,
+        local: "./public/jidicula-resume",
         // Only import the compiled PDF.
         patterns: `**.pdf`,
       },


### PR DESCRIPTION
**Why this change was necessary**
I want to have a copy of my resume available from my site that's
always up to date.

**What this change does**
This change configures the `gatsby-source-git` plugin to clone my
resume repo at the appropriate path that allows the PDF to be linked
from my Hello page.