### PR TITLE
config: Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jidicula

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
     day: "saturday"
     time: "06:00"
     timezone: "America/Toronto"
-  reviewers: ["jidicula"]
   open-pull-requests-limit: 10
   commit-message:
     prefix: "build: "
@@ -20,7 +19,6 @@ updates:
     day: "saturday"
     time: "06:00"
     timezone: "America/Toronto"
-  reviewers: ["jidicula"]
   open-pull-requests-limit: 10
   commit-message:
     prefix: "build: "


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners